### PR TITLE
 enable_snat: true for router

### DIFF
--- a/stack-single.yml
+++ b/stack-single.yml
@@ -282,6 +282,7 @@ resources:
     properties:
       external_gateway_info:
         network: {get_param: public}
+        enable_snat: true
 
   router_interface:
     type: OS::Neutron::RouterInterface

--- a/stack.yml
+++ b/stack.yml
@@ -487,6 +487,7 @@ resources:
     properties:
       external_gateway_info:
         network: {get_param: public}
+        enable_snat: true
 
   router_interface:
     type: OS::Neutron::RouterInterface

--- a/templates/stack.yml.j2
+++ b/templates/stack.yml.j2
@@ -490,6 +490,7 @@ resources:
     properties:
       external_gateway_info:
         network: {get_param: public}
+        enable_snat: true
 
   router_interface:
     type: OS::Neutron::RouterInterface


### PR DESCRIPTION
Some OpenStack deployments chose to not default to enable snat for their
routers. OTC is one example. While unusual, it's a valid choice.
This leads to instance not being able to access the internet which makes
the deployment fail.

enable_snat: true for the router takes care of it. It's harmless on
clouds where it's enabled by default.
